### PR TITLE
Make this add-on run before broccoli-asset-rev.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "ember-addon": {
+    "before": "broccoli-asset-rev"
+  },
   "author": "Moudy <moudy.elkammash@gmail.com>",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
broccoli-asset-rev is included by default with ember-cli, and may mess with
filesystem lookup.
